### PR TITLE
calendar synced with firebase information

### DIFF
--- a/CalorieCounter/app/src/main/java/edu/ucsb/cs/cs184/caloriecounter/AppRepository.kt
+++ b/CalorieCounter/app/src/main/java/edu/ucsb/cs/cs184/caloriecounter/AppRepository.kt
@@ -2,18 +2,15 @@ package edu.ucsb.cs.cs184.caloriecounter
 
 import android.app.Application
 import android.content.ContentValues.TAG
-import android.service.autofill.UserData
 import android.util.Log
 import androidx.lifecycle.MutableLiveData
 import com.google.firebase.auth.FirebaseAuth
-import com.google.firebase.auth.FirebaseUser
 import com.google.firebase.database.DataSnapshot
 import com.google.firebase.database.DatabaseError
 import com.google.firebase.database.FirebaseDatabase
 import com.google.firebase.database.ValueEventListener
 import com.google.firebase.database.ktx.database
 import com.google.firebase.ktx.Firebase
-import java.lang.ref.Reference
 import edu.ucsb.cs.cs184.caloriecounter.data.User
 
 class AppRepository (application: Application){
@@ -47,7 +44,9 @@ class AppRepository (application: Application){
                     calorie_array = listLongToInt(results?.get("calorie_array") as MutableList<Long>?),
 
                     streak = (results?.get("streak") as Long?)?.toInt() ?: 0,
-                    last_login = results?.get("last_login") as String?
+                    last_login = results?.get("last_login") as String?,
+
+                    history = (results?.get("history") as MutableList<String>?)
                 )
                 curUserMutableLiveData.postValue(userData)
             }
@@ -136,6 +135,12 @@ class AppRepository (application: Application){
 
     fun getName() : String?{
         return curUserMutableLiveData.value?.name
+    }
+
+    // - - - - - - - - Calendar - - - - - - - -
+
+    fun setHistory(array: MutableList<String>?) {
+        userRef.child(curUID).child("history").setValue(array)
     }
 
 }

--- a/CalorieCounter/app/src/main/java/edu/ucsb/cs/cs184/caloriecounter/data/User.kt
+++ b/CalorieCounter/app/src/main/java/edu/ucsb/cs/cs184/caloriecounter/data/User.kt
@@ -19,5 +19,6 @@ data class User(
     var calorie_array: MutableList<Int>? = null,
     // - - - - - - - date related - - - - - - - >
     var streak: Int? = 0,
-    var last_login: String? = null
+    var last_login: String? = null,
+    val history: MutableList<String>? = null
 )

--- a/CalorieCounter/app/src/main/java/edu/ucsb/cs/cs184/caloriecounter/ui/dashboard/DashboardFragment.kt
+++ b/CalorieCounter/app/src/main/java/edu/ucsb/cs/cs184/caloriecounter/ui/dashboard/DashboardFragment.kt
@@ -5,6 +5,7 @@ import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import androidx.fragment.app.Fragment
+import androidx.lifecycle.Observer
 import androidx.lifecycle.ViewModelProvider
 import edu.ucsb.cs.cs184.caloriecounter.R
 import edu.ucsb.cs.cs184.caloriecounter.databinding.FragmentDashboardBinding
@@ -40,6 +41,20 @@ class DashboardFragment : Fragment() {
         _binding = FragmentDashboardBinding.inflate(inflater, container, false)
         val root: View = binding.root
 
+        dashboardViewModel.getCurUserMutableLiveData().observe(viewLifecycleOwner, Observer {
+            dashboardViewModel.updateModel(it)
+            updateUI(binding, dashboardViewModel)
+        })
+
+        return root
+    }
+
+    override fun onDestroyView() {
+        super.onDestroyView()
+        _binding = null
+    }
+
+    fun updateUI(binding: FragmentDashboardBinding, dashboardViewModel: DashboardViewModel) {
         val calendarView = binding.calendarView
         val initialDate = dashboardViewModel.getInitialDate()
         val selectionMode = dashboardViewModel.getSelectionMode()
@@ -52,13 +67,6 @@ class DashboardFragment : Fragment() {
             showYearSelectionView = showYearSelectionView
         )
         calendarView.datesIndicators = this.getIndicators(dashboardViewModel.getIndicatorInformation())
-
-        return root
-    }
-
-    override fun onDestroyView() {
-        super.onDestroyView()
-        _binding = null
     }
 
 }

--- a/CalorieCounter/app/src/main/java/edu/ucsb/cs/cs184/caloriecounter/ui/home/HomeViewModel.kt
+++ b/CalorieCounter/app/src/main/java/edu/ucsb/cs/cs184/caloriecounter/ui/home/HomeViewModel.kt
@@ -54,6 +54,9 @@ class HomeViewModel(application: Application): AndroidViewModel(application) {
     private val _goalMet = MutableLiveData<Int>()
     val goalMet : MutableLiveData<Int> = _goalMet
 
+    private val _history = MutableLiveData<MutableList<String>>()
+    val history : MutableLiveData<MutableList<String>> = _history
+
     // data locking boolean flags
     private val _canIncreaseStreak = MutableLiveData<Boolean>().apply { value = false }
     private val _canDecreaseStreak = MutableLiveData<Boolean>().apply { value = false }
@@ -167,6 +170,19 @@ class HomeViewModel(application: Application): AndroidViewModel(application) {
         return lastLogin
     }
 
+    fun setHistory(lastLogin: String, metGoal: Int) {
+        val entry = "$lastLogin:$metGoal" // each item has the format "dd-mm-yyyy:{0/1}", eg. 01-06-2022:1 means met goal on June 1st 2022
+        var newHistory = curUserMutableLiveData.value!!.history
+        if (newHistory == null) {
+            newHistory = mutableListOf(entry)
+        }
+        else {
+            newHistory!!.add(entry)
+        }
+        this.history.value = newHistory
+        appRepository.setHistory(newHistory)
+    }
+
     // - - - - - - - - - - public functions - - - - - - - - - -
 
     //updates all data in the ViewModel once data has loaded.
@@ -225,6 +241,10 @@ class HomeViewModel(application: Application): AndroidViewModel(application) {
             val goalMet = this.goalMet.value
             if (goalMet == 0) {
                 this.setStreak(0)
+            }
+            // add entry to calendar
+            if (goalMet != null) {
+                this.setHistory(sdf.format(c.time), goalMet)
             }
 
             // unlock data changes


### PR DESCRIPTION
checkout branch and test

new:
- calendar will now fill out indicators according to data in firebase
- new user attribute "history", which contains a list of strings of the format "dd-mm-yyyy:{0/1}" which contains a date and did they meet or not meet their goal that day (0 or 1)

known issues:
- if you don't enter anything that day it still goes into firebase and shows up on the calendar the next day as a success/fail depending on if 0 calories was considered meeting your goal or not
- if you don't log in for a few days, last login's data is stored as yesterday's data even if you didn't log in yesterday (this was already present before this PR, it is the way the update streak date check stuff was implemented before)
